### PR TITLE
Update byte_buffer.h

### DIFF
--- a/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
+++ b/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 #include <ifm3d/fg/frame_grabber_export.h>
 


### PR DESCRIPTION
Include <string> allows build with Visual Studio 2019
Without the modification there is a compiler error the on line: std::string JSONModel();